### PR TITLE
Support for fetching a secret from nested data

### DIFF
--- a/template.go
+++ b/template.go
@@ -198,7 +198,9 @@ func (cmd *TemplateCommand) executeTemplateNested(client *Client, input string) 
 				keys := strings.Split(k, ".")
 
 				var nestedData map[string]interface{}
-				json.Unmarshal([]byte(secret.Data[keys[0]].(string)), &nestedData)
+				if err := json.Unmarshal([]byte(secret.Data[keys[0]].(string)), &nestedData); err != nil {
+					return "", fmt.Errorf("nested %s/%s: failed to parse JSON", path, keys[0])
+				}
 
 				mydata := nestedData
 				levels := len(keys) - 1

--- a/template.go
+++ b/template.go
@@ -3,12 +3,14 @@ package vc
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"html/template"
 	"io"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -78,6 +80,7 @@ func (cmd *TemplateCommand) parseTemplate(name string) (*template.Template, erro
 	return template.New(name).Funcs(template.FuncMap{
 		"decode": cmd.templateDecode,
 		"secret": cmd.templateSecret,
+		"nested": cmd.templateNested,
 	}).Parse(string(b))
 }
 
@@ -105,6 +108,9 @@ func (cmd *TemplateCommand) executeTemplate(t *template.Template) (content strin
 		return
 	}
 	if content, err = cmd.executeTemplateSecrets(client, content); err != nil {
+		return
+	}
+	if content, err = cmd.executeTemplateNested(client, content); err != nil {
 		return
 	}
 
@@ -160,11 +166,59 @@ func (cmd *TemplateCommand) executeTemplateSecrets(client *Client, input string)
 
 		// For each of the secret keys, lookup the value
 		for k, placeholder := range kv {
-			if v, ok := secret.Data[k].(string); ok {
-				content = strings.Replace(content, placeholder, v, -1)
-			} else {
-				return "", fmt.Errorf("secret %s: key %q not found", path, k)
+			if strings.HasPrefix(placeholder, "_VAULT_STRING_") {
+				if v, ok := secret.Data[k].(string); ok {
+					content = strings.Replace(content, placeholder, v, -1)
+				} else {
+					return "", fmt.Errorf("secret %s: key %q not found", path, k)
+				}
 			}
+		}
+	}
+
+	return
+}
+
+func (cmd *TemplateCommand) executeTemplateNested(client *Client, input string) (content string, err error) {
+	content = input
+
+	// For each of the secret paths, lookup the secret
+	for path, kv := range cmd.lookup {
+		var secret *api.Secret
+		if secret, err = client.Logical().Read(strings.TrimLeft(path, "/")); err != nil {
+			return
+		}
+		if secret == nil {
+			return "", fmt.Errorf("nested %s: not found", path)
+		}
+
+		// For each of the secret keys, lookup the value
+		for k, placeholder := range kv {
+			if strings.HasPrefix(placeholder, "_VAULT_NESTED_") {
+				keys := strings.Split(k, ".")
+
+				var nestedData map[string]interface{}
+				json.Unmarshal([]byte(secret.Data[keys[0]].(string)), &nestedData)
+
+				mydata := nestedData
+				levels := len(keys) - 1
+				for _, nestedkey := range keys[1:] {
+					if levels > 1 {
+						if mydata[nestedkey] == nil {
+							return "", fmt.Errorf("nested %s: key %q not found", path, nestedkey)
+						}
+						mydata = mydata[nestedkey].(map[string]interface{})
+					} else {
+						if reflect.TypeOf(mydata[nestedkey]).Kind() == reflect.String {
+							content = strings.Replace(content, placeholder, mydata[nestedkey].(string), -1)
+						} else {
+							return "", fmt.Errorf("nested %s: key %q is not a string", path, nestedkey)
+						}
+					}
+					levels--
+				}
+			}
+
 		}
 	}
 
@@ -187,6 +241,22 @@ func (cmd *TemplateCommand) templateSecret(path string, key string) string {
 
 	if _, ok = kv[key]; !ok {
 		kv[key] = cmd.randomIdentifier("string")
+	}
+
+	return kv[key]
+}
+
+func (cmd *TemplateCommand) templateNested(path string, key string) string {
+	// keys := strings.Split(key, ".")
+
+	kv, ok := cmd.lookup[path]
+	if !ok {
+		cmd.lookup[path] = make(map[string]string)
+		kv = cmd.lookup[path]
+	}
+
+	if _, ok = kv[key]; !ok {
+		kv[key] = cmd.randomIdentifier("nested")
 	}
 
 	return kv[key]

--- a/template.go
+++ b/template.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -211,7 +210,7 @@ func (cmd *TemplateCommand) executeTemplateNested(client *Client, input string) 
 						}
 						mydata = mydata[nestedkey].(map[string]interface{})
 					} else {
-						if reflect.TypeOf(mydata[nestedkey]).Kind() == reflect.String {
+						if _, ok := mydata[nestedkey].(string); ok {
 							content = strings.Replace(content, placeholder, mydata[nestedkey].(string), -1)
 						} else {
 							return "", fmt.Errorf("nested %s: key %q is not a string", path, nestedkey)


### PR DESCRIPTION
Example template:
```
my_api_key: {{ nested "my/secret/path" "apikeys.foo.bar" }}
```

Example data:
```
{
    "apikeys": {
        "foo": {
            "bar": "my_secret_data"
        }
    }
}
```

Issues: direct usage of `encoding/json` in `template.go`. This should
probably be replaced with abstraction based on `Data["__TYPE__"]`.