### PR TITLE
Support text/template in `vc template`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ text/template, see https://golang.org/pkg/text/template/
 
     Options:
       -m string
-        	output mode (default 0600)
+            output mode (default 0600)
       -o string
-        	output (default: stdout)
+            output (default: stdout)
+      -t string
+            templating mode: html or text (default html)
 
 
 The render engine will first evaluate the template file and retrieve all

--- a/base.go
+++ b/base.go
@@ -119,7 +119,9 @@ func (cmd *baseCommand) Close() error {
 // if the caller calls .Close(), the file gets renamed to cmd.out
 func (cmd *baseCommand) writerOpen() error {
 	if cmd.out == "" || cmd.out == "-" {
-		cmd.w = os.Stdout
+		if cmd.w == nil {
+			cmd.w = os.Stdout
+		}
 		return nil
 	}
 

--- a/template_test.go
+++ b/template_test.go
@@ -1,0 +1,178 @@
+package vc
+
+import (
+	"bytes"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/cli"
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+)
+
+func TestTemplateCommand_Run(t *testing.T) {
+
+	_, vaultClient := createTestVault(t)
+	writeSecret(t, vaultClient, "secret/foo/bar", map[string]interface{}{
+		"secret": "bar",
+	})
+
+	commandUnderTest, output := createCommandUnderTest(t, vaultClient)
+	f := createTemplateFile(t, "Test template {{ secret \"secret/foo/bar\" \"secret\" }}")
+
+	exitCode := commandUnderTest.Run([]string{f.Name()})
+	commandOutput := output.String()
+	if exitCode != 0 {
+		t.Fatal("Exit code is not 0", commandOutput, exitCode)
+	}
+
+	if commandOutput != "Test template bar" {
+		t.Fatal("Unexpected output", "'"+commandOutput+"'")
+	}
+}
+
+func TestTemplateCommand_EscapeXml(t *testing.T) {
+	_, vaultClient := createTestVault(t)
+	writeSecret(t, vaultClient, "secret/foo/bar", map[string]interface{}{
+		"secret": "bar",
+	})
+
+	commandUnderTest, output := createCommandUnderTest(t, vaultClient)
+	f := createTemplateFile(t,
+		`<?xml version="1.0" encoding="utf-8"?>
+<item>
+     <value>{{ secret "secret/foo/bar" "secret" }}</value>
+<item>
+`)
+
+	exitCode := commandUnderTest.Run([]string{f.Name()})
+	commandOutput := output.String()
+	if exitCode != 0 {
+		t.Fatal("Exit code is not 0", commandOutput, exitCode)
+	}
+
+	expectedOutput := `&lt;?xml version="1.0" encoding="utf-8"?>
+<item>
+     <value>bar</value>
+<item>
+`
+	if commandOutput != expectedOutput {
+		t.Fatal("Unexpected output", "'"+commandOutput+"'")
+	}
+}
+
+func TestTemplateCommand_TextTemplateXml(t *testing.T) {
+	_, vaultClient := createTestVault(t)
+	writeSecret(t, vaultClient, "secret/foo/bar", map[string]interface{}{
+		"secret": "bar",
+	})
+
+	commandUnderTest, output := createCommandUnderTest(t, vaultClient)
+	commandUnderTest.templatingMode = "text"
+	f := createTemplateFile(t,
+		`<?xml version="1.0" encoding="utf-8"?>
+<item>
+     <value>{{ secret "secret/foo/bar" "secret" }}</value>
+<item>
+`)
+
+	exitCode := commandUnderTest.Run([]string{f.Name()})
+	commandOutput := output.String()
+	if exitCode != 0 {
+		t.Fatal("Exit code is not 0", commandOutput, exitCode)
+	}
+
+	expectedOutput := `<?xml version="1.0" encoding="utf-8"?>
+<item>
+     <value>bar</value>
+<item>
+`
+	if commandOutput != expectedOutput {
+		t.Fatal("Unexpected output", "'"+commandOutput+"'")
+	}
+}
+
+func writeSecret(t *testing.T, vaultClient *api.Client, path string, secret map[string]interface{}) {
+	_, err := vaultClient.Logical().Write(path, secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createTemplateFile(t *testing.T, templateContents string) *os.File {
+	f, err := ioutil.TempFile(".", "template")
+	t.Cleanup(func() {
+		_ = os.Remove(f.Name())
+	})
+
+	if err != nil {
+		t.Fatal("Failed to create temp file", err)
+	}
+	_, err = f.Write([]byte(templateContents))
+	if err != nil {
+		t.Fatal("Failed to write to temp file", err)
+	}
+	_ = f.Close()
+	return f
+}
+
+func createCommandUnderTest(t *testing.T, client *api.Client) (*TemplateCommand, *bytes.Buffer) {
+	b := new(bytes.Buffer)
+
+	ui := &cli.BasicUi{
+		Reader:      nil,
+		Writer:      b,
+		ErrorWriter: b,
+	}
+	factory := TemplateCommandFactory(ui)
+	commandUnderTest, err := factory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	templateCommand := commandUnderTest.(*TemplateCommand)
+	templateCommand.c = &Client{
+		Path:   "/",
+		Client: client,
+	}
+	templateCommand.w = &byteBufferWriteCloser{ByteBuffer: b}
+
+	return templateCommand, b
+}
+
+func createTestVault(t *testing.T) (net.Listener, *api.Client) {
+	t.Helper()
+
+	// Create an in-memory, unsealed core (the "backend", if you will).
+	core, keyShares, rootToken := vault.TestCoreUnsealed(t)
+	_ = keyShares
+
+	// Start an HTTP server for the core.
+	listener, addr := http.TestServer(t, core)
+
+	// Create a client that talks to the server, initially authenticating with
+	// the root token.
+	conf := api.DefaultConfig()
+	conf.Address = addr
+
+	client, err := api.NewClient(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SetToken(rootToken)
+
+	return listener, client
+}
+
+type byteBufferWriteCloser struct {
+	ByteBuffer *bytes.Buffer
+}
+
+func (t *byteBufferWriteCloser) Write(data []byte) (int, error) {
+	return t.ByteBuffer.Write(data)
+}
+
+func (t *byteBufferWriteCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
`vc template` doesn't handle XML templates well -- it escapes some XML
characters making rendered template invalid XML. To mitigate this `-t`
parameter with values `text` and `html` (default) was introduced.
If this parameter is set to `html` `html/template` go module is used for
templating (old behavior with XML characters escaping), if it is set to
`text` `text/template` go module is used which doesn't do any escaping
whatsoever.