### PR TITLE
Add -u (output file user) and -g (output file group) to `cat` and `template` parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,17 @@ Show the contents of a secret.
     Usage: vc cat [<options>] <secret path>
 
     Options:
-     -k string
-       	key (default __TYPE__)
-     -m string
-       	output mode (default 0600)
-     -o string
-       	output (default: stdout)
+      -i    ingore missing key
+      -k string
+            key
+      -m string
+            output mode (default 0600)
+      -o string
+            output (default stdout)
+      -u string
+            output file user name or numeric user id (default: current user)
+      -g string
+            output file group name or numeric group id (default: current group)
 
 
 ## Command edit
@@ -120,6 +125,10 @@ text/template, see https://golang.org/pkg/text/template/
             output (default: stdout)
       -t string
             templating mode: html or text (default html)
+      -u string
+            output file user name or numeric user id (default: current user)
+      -g string
+            output file group name or numeric group id (default: current group)
 
 
 The render engine will first evaluate the template file and retrieve all

--- a/cat.go
+++ b/cat.go
@@ -209,6 +209,8 @@ func CatCommandFactory(ui cli.Ui) cli.CommandFactory {
 		cmd.fs.StringVar(&cmd.key, "k", "", "key")
 		cmd.fs.StringVar(&cmd.mod, "m", "0600", "output mode")
 		cmd.fs.StringVar(&cmd.out, "o", "", "output (default stdout)")
+		cmd.fs.StringVar(&cmd.user, "u", "", "output file user name or numeric user id (default: current user)")
+		cmd.fs.StringVar(&cmd.group, "g", "", "output file group name or numeric group id (default: current group)")
 		cmd.fs.Usage = func() {
 			fmt.Print(cmd.Help())
 		}

--- a/template.go
+++ b/template.go
@@ -297,6 +297,8 @@ func TemplateCommandFactory(ui cli.Ui) cli.CommandFactory {
 		cmd.fs.StringVar(&cmd.mod, "m", "0600", "output mode")
 		cmd.fs.StringVar(&cmd.out, "o", "", "output (default: stdout)")
 		cmd.fs.StringVar(&cmd.templatingMode, "t", "html", "templating mode: html or text")
+		cmd.fs.StringVar(&cmd.user, "u", "", "output file user name or numeric user id (default: current user)")
+		cmd.fs.StringVar(&cmd.group, "g", "", "output file group name or numeric group id (default: current group)")
 		cmd.fs.Usage = func() {
 			fmt.Print(cmd.Help())
 		}


### PR DESCRIPTION
Sometimes its needed to create output file with user and
group different from the current ones (e.g. when we do `vc cat` from
conjob which runs as root, but we want the file to have other owner).
Of course, one can just do `chown` right after `vc cat` or `vc template` but
this won't be atomic. I added `-u` and `-g` parameters which make chown
operation on temp file created in `baseCommand.writerOpen`, thus making
ownership change atomic.